### PR TITLE
Add support for Ed25519, with tests

### DIFF
--- a/peer.go
+++ b/peer.go
@@ -2,6 +2,7 @@
 package peer
 
 import (
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"strings"
@@ -9,6 +10,7 @@ import (
 	logging "github.com/ipfs/go-log" // ID represents the identity of a peer.
 	b58 "github.com/jbenet/go-base58"
 	ic "github.com/libp2p/go-libp2p-crypto"
+	mc "github.com/multiformats/go-multicodec-packed"
 	mh "github.com/multiformats/go-multihash"
 )
 
@@ -61,6 +63,69 @@ func (id ID) MatchesPublicKey(pk ic.PubKey) bool {
 		return false
 	}
 	return oid == id
+}
+
+func (id ID) ExtractEd25519PublicKey() ic.PubKey {
+	// ed25519 pubkey identity format
+	// <identity mc><length (2 + 32 = 34)><ed25519-pub mc><ed25519 pubkey>
+	// <0x00       ><0x22                ><0xed01        ><ed25519 pubkey>
+
+	var nilPubKey ic.PubKey
+
+	// Decode multihash
+	decoded, err := mh.Decode([]byte(id))
+	if err != nil {
+		// This error should not occur for any identity
+		log.Error("Unable to decode multihash", id)
+		return nilPubKey
+	}
+
+	// Check ID multihash codec
+	if decoded.Code != mh.ID {
+		return nilPubKey
+	}
+
+	// Check multihash length
+	if decoded.Length != 2+32 {
+		return nilPubKey
+	}
+
+	// Split prefix
+	code, pubKeyBytes := mc.SplitPrefix(decoded.Digest)
+
+	// Check ed25519 code
+	if code != mc.Ed25519Pub {
+		return nilPubKey
+	}
+
+	// Unmarshall public key
+	pubKey, err := ic.UnmarshalEd25519PublicKey(pubKeyBytes)
+	if err != nil {
+		// Should never occur because of the check decoded.Length != 2+32
+		log.Fatal("Unexpected error unmarshalling Ed25519 public key")
+		return nilPubKey
+	}
+
+	return pubKey
+}
+
+// ExtractPublicKey attempts to extract the public key from an ID
+func (id ID) ExtractPublicKey() ic.PubKey {
+	var pk ic.PubKey
+
+	// Try extract ed25519 pubkey
+	pk = id.ExtractEd25519PublicKey()
+	if pk != nil {
+		return pk
+	}
+
+	// Try extract other type of pubkey
+	/*pk = id.Extract...PublicKey()
+	if pk != nil {
+		return pk
+	}*/
+
+	return pk
 }
 
 // IDFromString cast a string to ID type, and validate
@@ -116,6 +181,25 @@ func IDFromPublicKey(pk ic.PubKey) (ID, error) {
 		return "", err
 	}
 	hash, _ := mh.Sum(b, mh.SHA2_256, -1)
+	return ID(hash), nil
+}
+
+// IDFromEd25519PublicKey returns the Peer ID corresponding to Id25519 pk
+func IDFromEd25519PublicKey(pk ic.PubKey) (ID, error) {
+	b, err := pk.Bytes()
+	if err != nil {
+		return "", err
+	}
+
+	// Build the ed25519 public key multi-codec
+	Ed25519PubMultiCodec := make([]byte, 2)
+	binary.PutUvarint(Ed25519PubMultiCodec, uint64(mc.Ed25519Pub))
+
+	hash, err := mh.Sum(append(Ed25519PubMultiCodec, b[len(b)-32:]...), mh.ID, 34)
+	if err != nil {
+		return "", err
+	}
+
 	return ID(hash), nil
 }
 

--- a/peer_test.go
+++ b/peer_test.go
@@ -185,25 +185,25 @@ func TestEd25519PublicKeyExtraction(t *testing.T) {
 
 	// Error case 1: Invalid multihash
 	_, err = ID("").ExtractEd25519PublicKey()
-	if err.Error() != "Unable to decode multihash" {
+	if err != MultihashDecodeErr {
 		t.Fatal("Error case 1: Expected an error")
 	}
 
 	// Error case 2: Non-ID multihash
 	_, err = ID(append([]byte{0x01 /* != 0x00 (id) */, 0x22, 0xed, 0x01}, randomKey...)).ExtractEd25519PublicKey()
-	if err.Error() != "Unexpected multihash codec" {
+	if err != MultihashCodecErr {
 		t.Fatal("Error case 2: Expecting an error")
 	}
 
 	// Error case 3: Non-34 multihash length
 	_, err = ID(append([]byte{0x00, 0x23 /* 35 = 34 + 1 != 35 */, 0xed, 0x01, 0x00 /* extra byte */}, randomKey...)).ExtractEd25519PublicKey()
-	if err.Error() != "Unexpected multihash length" {
+	if err != MultihashLengthErr {
 		t.Fatal("Error case 3: Expecting an error")
 	}
 
 	// Error case 4: Non-ed25519 code
 	_, err = ID(append([]byte{0x00, 0x22, 0xef /* != 0xed */, 0x01}, randomKey...)).ExtractEd25519PublicKey()
-	if err.Error() != "Unexpected code prefix" {
+	if err != CodePrefixErr {
 		t.Fatal("Error case 4: Expecting an error")
 	}
 }

--- a/peer_test.go
+++ b/peer_test.go
@@ -183,19 +183,28 @@ func TestEd25519PublicKeyExtraction(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Error case 1: Non-ID multihash
-	if ID(append([]byte{0x01 /* != 0x00 (id) */, 0x22, 0xed, 0x01}, randomKey...)).ExtractEd25519PublicKey() != nil {
-		t.Fatal("Error case 1: Expecting a nil public key")
+	// Error case 1: Invalid multihash
+	_, err = ID("").ExtractEd25519PublicKey()
+	if err.Error() != "Unable to decode multihash" {
+		t.Fatal("Error case 1: Expected an error")
 	}
 
-	// Error case 2: Non-34 multihash length
-	if ID(append([]byte{0x00, 0x23 /* 35 = 34 + 1 != 35 */, 0xed, 0x01, 0x00 /* extra byte */}, randomKey...)).ExtractEd25519PublicKey() != nil {
-		t.Fatal("Error case 2: Expecting a nil public key")
+	// Error case 2: Non-ID multihash
+	_, err = ID(append([]byte{0x01 /* != 0x00 (id) */, 0x22, 0xed, 0x01}, randomKey...)).ExtractEd25519PublicKey()
+	if err.Error() != "Unexpected multihash codec" {
+		t.Fatal("Error case 2: Expecting an error")
 	}
 
-	// Error case 3: Non-ed25519 code
-	if ID(append([]byte{0x00, 0x22, 0xef /* != 0xed */, 0x01}, randomKey...)).ExtractEd25519PublicKey() != nil {
-		t.Fatal("Error case 3: Expecting a nil public key")
+	// Error case 3: Non-34 multihash length
+	_, err = ID(append([]byte{0x00, 0x23 /* 35 = 34 + 1 != 35 */, 0xed, 0x01, 0x00 /* extra byte */}, randomKey...)).ExtractEd25519PublicKey()
+	if err.Error() != "Unexpected multihash length" {
+		t.Fatal("Error case 3: Expecting an error")
+	}
+
+	// Error case 4: Non-ed25519 code
+	_, err = ID(append([]byte{0x00, 0x22, 0xef /* != 0xed */, 0x01}, randomKey...)).ExtractEd25519PublicKey()
+	if err.Error() != "Unexpected code prefix" {
+		t.Fatal("Error case 4: Expecting an error")
 	}
 }
 


### PR DESCRIPTION
This pull request adds support for Ed25519. It adds three functions `ExtractEd25519PublicKey`, `ExtractPublicKey` and `IDFromEd25519PublicKey`. The issues in [the original pull-request](https://github.com/libp2p/go-libp2p-peer/pull/13) have been addressed. In particular,

- I have added tests for the happy path and the error paths
- I have added more comments
- I am logging the multihash decode error, indicating something bad happened
- I am doing `log.Fatal` on an error which should not be possible to hit when unmarshalling the ed25519 public key

cc @lgierth, @whyrusleeping, @Kubuxu