### PR TITLE
Add example of generating peer ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,24 @@ TODO
 
 ## Usage
 
-TODO
+Generate a peers ID:
+
+```go
+import (
+        "crypto/rand"
+
+        crypto "github.com/libp2p/go-libp2p-crypto"
+        peer "github.com/libp2p/go-libp2p-peer"
+)
+
+// Generate an identity keypair using go's cryptographic randomness source
+priv, pub, err := crypto.GenerateEd25519Key(rand.Reader)
+if err != nil { panic(err) }
+
+// A peers ID is the hash of its public key
+pid, err := peer.IDFromPublicKey(pub)
+if err != nil { panic(err) }
+```
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ pid, err := peer.IDFromPublicKey(pub)
 if err != nil { panic(err) }
 ```
 
+Go to https://godoc.org/github.com/libp2p/go-libp2p-peer
+
 ## Contribute
 
 Feel free to join in. All welcome. Open an [issue](https://github.com/ipfs/go-libp2p-peer/issues)!

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ if err != nil { panic(err) }
 // A peers ID is the hash of its public key
 pid, err := peer.IDFromPublicKey(pub)
 if err != nil { panic(err) }
+
+// A peers ID corresponding to Ed25519 pk
+// embeds the public key in the ID itself
+pid, err := peer.IDFromEd25519PublicKey
+if err != nil { panic(err) }
+
 ```
 
 Go to https://godoc.org/github.com/libp2p/go-libp2p-peer


### PR DESCRIPTION
Taken from the lib-p2p example

https://github.com/libp2p/go-libp2p/tree/master/examples/libp2p-host