### PR TITLE
Make nodeID calculation pluggable

### DIFF
--- a/peer.go
+++ b/peer.go
@@ -19,7 +19,7 @@ var log = logging.Logger("peer")
 
 type ID string
 
-var PluggableIDFromPublicKey = defaultIDFromPublicKey
+var PluggableIDFromPublicKey = DefaultIDFromPublicKey
 
 // Pretty returns a b58-encoded string of the ID
 func (id ID) Pretty() string {
@@ -192,7 +192,7 @@ func IDFromPublicKey(pk ic.PubKey) (ID, error) {
 	return PluggableIDFromPublicKey(pk)
 }
 
-func defaultIDFromPublicKey(pk ic.PubKey) (ID, error) {
+func DefaultIDFromPublicKey(pk ic.PubKey) (ID, error) {
 	b, err := pk.Bytes()
 	if err != nil {
 		return "", err

--- a/peer.go
+++ b/peer.go
@@ -19,6 +19,8 @@ var log = logging.Logger("peer")
 
 type ID string
 
+var PluggableIDFromPublicKey = defaultIDFromPublicKey
+
 // Pretty returns a b58-encoded string of the ID
 func (id ID) Pretty() string {
 	return IDB58Encode(id)
@@ -187,6 +189,10 @@ func IDHexEncode(id ID) string {
 
 // IDFromPublicKey returns the Peer ID corresponding to pk
 func IDFromPublicKey(pk ic.PubKey) (ID, error) {
+	return PluggableIDFromPublicKey(pk)
+}
+
+func defaultIDFromPublicKey(pk ic.PubKey) (ID, error) {
 	b, err := pk.Bytes()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
The calculation of the NodeID from the public key seems arbitrary and applications should be able to override this calculation in ways that align to their usage.  