### PR TITLE
fix RandTestKeyPair on windows

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-2.2.3: QmZoWKhxUmZ2seW4BzX6fJkNR8hh9PsGModr7q171yq2SS
+2.2.4: QmQnuSxgSFubscHgkgSeayLxKmVcmNhFUaZw4gHtV3tJ15

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
   "license": "MIT",
   "name": "go-libp2p-peer",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "2.2.3"
+  "version": "2.2.4"
 }
 

--- a/test/utils.go
+++ b/test/utils.go
@@ -3,12 +3,15 @@ package testutil
 import (
 	"io"
 	"math/rand"
+	"sync/atomic"
 	"time"
 
 	ci "github.com/libp2p/go-libp2p-crypto"
 	peer "github.com/libp2p/go-libp2p-peer"
 	mh "github.com/multiformats/go-multihash"
 )
+
+var generatedPairs int64 = 0
 
 func RandPeerID() (peer.ID, error) {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
@@ -21,7 +24,12 @@ func RandPeerID() (peer.ID, error) {
 }
 
 func RandTestKeyPair(bits int) (ci.PrivKey, ci.PubKey, error) {
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	seed := time.Now().UnixNano()
+
+	// workaround for low time resolution
+	seed += atomic.AddInt64(&generatedPairs, 1) << 32
+
+	r := rand.New(rand.NewSource(seed))
 	return ci.GenerateKeyPairWithReader(ci.RSA, bits, r)
 }
 


### PR DESCRIPTION
Resolution of `time.Now().UnixNano()` on windows is quite low, which results in generating identical key pairs when this is called in quick succession.