### PR TITLE
change how we calculate inline peer IDs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,12 +26,6 @@
       "version": "1.0.7"
     },
     {
-      "author": "whyrusleeping",
-      "hash": "QmNhVCV7kgAqW6oh6n8m9myxT2ksGPhVZnHkzkBvR5qg2d",
-      "name": "go-multicodec-packed",
-      "version": "0.1.0"
-    },
-    {
       "author": "mr-tron",
       "hash": "QmWFAMPqsEyUX7gDUsRVmMWz59FxSpJ1b2v6bJ1yYzo7jY",
       "name": "go-base58-fast",

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmaPbCnUMBohSGo3KnxEa2bHqyJVVeEEcwtqJAYxerieBo",
+      "hash": "Qmb9aAJwV1mDc5iPNtVuzVvsNiKA6kkDpZspMUgVfXPVc8",
       "name": "go-libp2p-crypto",
-      "version": "1.5.0"
+      "version": "1.6.0"
     },
     {
       "author": "multiformats",


### PR DESCRIPTION
Instead of trying to get fancy with multicodecs and such, just inline the public key's protobuf (if it's small enough).

**Before:**

Currently, we *always* use sha256-256 multihash's *except* when the user explicitly uses the `IDFromEd25519PublicKey` function. That function returns the identity multihash of the ed25519 multicodec concatenated with the ed25519 public key).

**After:**

1. Serialize the public key protobuf.
2. If it's <= 40 bytes long, return the identity multihash as the peer ID.
3. If it's > 40 bytes long, return the sha256-256 multihash as the peer ID.

---

Eventually, we can try to switch to true IPLD but this is, IMO, a step in the right direction.

This is a massively **breaking change** for anyone using ed25519 keys but:

1. Ensures that any given key *always* has the same peer ID.
2. Removes key-specific logic. If the key protobuf fits in under 40 bytes (32 bytes for the key + 8 for the key type, protobuf stuff, and maybe an additional field).

* [ ] Is 40 bytes the right size? Once we decide, we should set this in stone. Otherwise, we'll end up with disagreeing peer IDs again.
* [ ] What about the hash function? We currently hard-code sha2-256... punt? Make this a part of the key "type"?

fixes #29