### PR TITLE
improve peer ID formatting for ed25519 PIDs

### DIFF
--- a/peer.go
+++ b/peer.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"strings"
 
 	logging "github.com/ipfs/go-log"
 	ic "github.com/libp2p/go-libp2p-crypto"
@@ -52,18 +51,10 @@ func (id ID) Loggable() map[string]interface{} {
 // codebase is known to be correct.
 func (id ID) String() string {
 	pid := id.Pretty()
-
-	//All sha256 nodes start with Qm
-	//We can skip the Qm to make the peer.ID more useful
-	if strings.HasPrefix(pid, "Qm") {
-		pid = pid[2:]
+	if len(pid) <= 10 {
+		return fmt.Sprintf("<peer.ID %s>", pid)
 	}
-
-	maxRunes := 6
-	if len(pid) < maxRunes {
-		maxRunes = len(pid)
-	}
-	return fmt.Sprintf("<peer.ID %s>", pid[:maxRunes])
+	return fmt.Sprintf("<peer.ID %s*%s>", pid[:2], pid[len(pid)-6:])
 }
 
 // MatchesPrivateKey tests whether this ID was derived from sk


### PR DESCRIPTION
Given that we're using the ID multihash for these keys, they don't start with Qm. As a matter of fact, given the protobuf format, the first few bytes will always be the same.

To fix this, this patch takes the first two bytes and the last 6 bytes. That allows us to tell the hash function *and* gives us some unique bytes for identification.