### PR TITLE
fix ExtractPublicKey semantics to return an error when it can't extract the public key

### DIFF
--- a/peer.go
+++ b/peer.go
@@ -23,6 +23,8 @@ const MaxInlineKeyLength = 42
 var (
 	// ErrEmptyPeerID is an error for empty peer ID.
 	ErrEmptyPeerID = errors.New("empty peer ID")
+	// ErrNoPublickKey is an error for peer IDs that don't embed public keys
+	ErrNoPublicKey = errors.New("public key is not embedded in peer ID")
 )
 
 // ID is a libp2p peer identity.
@@ -70,7 +72,7 @@ func (id ID) MatchesPublicKey(pk ic.PubKey) bool {
 
 // ExtractPublicKey attempts to extract the public key from an ID
 //
-// This method returns nil, nil if the peer ID looks valid but it can't extract
+// This method returns ErrNoPublicKey if the peer ID looks valid but it can't extract
 // the public key.
 func (id ID) ExtractPublicKey() (ic.PubKey, error) {
 	decoded, err := mh.Decode([]byte(id))
@@ -78,7 +80,7 @@ func (id ID) ExtractPublicKey() (ic.PubKey, error) {
 		return nil, err
 	}
 	if decoded.Code != mh.ID {
-		return nil, nil
+		return nil, ErrNoPublicKey
 	}
 	pk, err := ic.UnmarshalPublicKey(decoded.Digest)
 	if err != nil {

--- a/peer_test.go
+++ b/peer_test.go
@@ -196,7 +196,7 @@ func TestPublicKeyExtraction(t *testing.T) {
 		t.Fatal(err)
 	}
 	extractedRsaPub, err := rsaId.ExtractPublicKey()
-	if err != nil {
+	if err != ErrNoPublicKey {
 		t.Fatal(err)
 	}
 	if extractedRsaPub != nil {


### PR DESCRIPTION
Fixes #38 