### PR TITLE
disable key inlining

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: go
 sudo: false
 
 go:
-  - 1.9.x
+  - 1.11.x
 
 install:
   - make deps

--- a/peer.go
+++ b/peer.go
@@ -11,15 +11,6 @@ import (
 	mh "github.com/multiformats/go-multihash"
 )
 
-// MaxInlineKeyLength is the maximum length a key can be for it to be inlined in
-// the peer ID.
-//
-// * When `len(pubKey.Bytes()) <= MaxInlineKeyLength`, the peer ID is the
-//   identity multihash hash of the public key.
-// * When `len(pubKey.Bytes()) > MaxInlineKeyLength`, the peer ID is the
-//   sha2-256 multihash of the public key.
-const MaxInlineKeyLength = 42
-
 var (
 	// ErrEmptyPeerID is an error for empty peer ID.
 	ErrEmptyPeerID = errors.New("empty peer ID")
@@ -150,11 +141,7 @@ func IDFromPublicKey(pk ic.PubKey) (ID, error) {
 	if err != nil {
 		return "", err
 	}
-	var alg uint64 = mh.SHA2_256
-	if len(b) <= MaxInlineKeyLength {
-		alg = mh.ID
-	}
-	hash, _ := mh.Sum(b, alg, -1)
+	hash, _ := mh.Sum(b, mh.SHA2_256, -1)
 	return ID(hash), nil
 }
 

--- a/peer_test.go
+++ b/peer_test.go
@@ -154,6 +154,7 @@ func TestIDMatchesPrivateKey(t *testing.T) {
 }
 
 func TestPublicKeyExtraction(t *testing.T) {
+	t.Skip("disabled until libp2p/go-libp2p-crypto#51 is fixed")
 	// Happy path
 	_, originalPub, err := ic.GenerateEd25519Key(rand.Reader)
 	if err != nil {


### PR DESCRIPTION
disable peer ID inlining until we fix: https://github.com/libp2p/specs/issues/111

Note: This is a *bit* tricky because we currently throw away everything except the key type and data. However, we'll need to support arbitrary hash functions for keys *regardless* so there's nothing we can do here but bite the bullet and fix this.