### PR TITLE
Protobuf and JSON (un-)marshalling methods for peer.ID

### DIFF
--- a/peer_serde.go
+++ b/peer_serde.go
@@ -3,14 +3,13 @@ package peer
 
 import (
 	"encoding/json"
-
-	"github.com/golang/protobuf/proto"
 )
 
-var _ proto.Marshaler = (*ID)(nil)
-var _ proto.Unmarshaler = (*ID)(nil)
+// Interface assertions commented out to avoid introducing hard dependencies to protobuf.
+// var _ proto.Marshaler = (*ID)(nil)
+// var _ proto.Unmarshaler = (*ID)(nil)
 var _ json.Marshaler = (*ID)(nil)
-var _ proto.Unmarshaler = (*ID)(nil)
+var _ json.Unmarshaler = (*ID)(nil)
 
 func (id ID) Marshal() ([]byte, error) {
 	return []byte(id), nil

--- a/peer_serde.go
+++ b/peer_serde.go
@@ -1,0 +1,39 @@
+// This file contains Protobuf and JSON serialization/deserialization methods for peer IDs.
+package peer
+
+import (
+	"encoding/json"
+
+	"github.com/golang/protobuf/proto"
+)
+
+var _ proto.Marshaler = (*ID)(nil)
+var _ proto.Unmarshaler = (*ID)(nil)
+var _ json.Marshaler = (*ID)(nil)
+var _ proto.Unmarshaler = (*ID)(nil)
+
+func (id ID) Marshal() ([]byte, error) {
+	return []byte(id), nil
+}
+
+func (id ID) MarshalTo(data []byte) (n int, err error) {
+	return copy(data, []byte(id)), nil
+}
+
+func (id *ID) Unmarshal(data []byte) (err error) {
+	*id, err = IDFromBytes(data)
+	return err
+}
+
+func (id ID) MarshalJSON() ([]byte, error) {
+	return json.Marshal(IDB58Encode(id))
+}
+
+func (id *ID) UnmarshalJSON(data []byte) (err error) {
+	var v string
+	if err = json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+	*id, err = IDB58Decode(v)
+	return err
+}

--- a/peer_serde.go
+++ b/peer_serde.go
@@ -25,6 +25,12 @@ func (id *ID) Unmarshal(data []byte) (err error) {
 	return err
 }
 
+// Implements Gogo's proto.Sizer, but we omit the compile-time assertion to avoid introducing a hard
+// dependency on gogo.
+func (id ID) Size() int {
+	return len([]byte(id))
+}
+
 func (id ID) MarshalJSON() ([]byte, error) {
 	return json.Marshal(IDB58Encode(id))
 }

--- a/peer_serde_test.go
+++ b/peer_serde_test.go
@@ -1,0 +1,45 @@
+package peer_test
+
+import (
+	"testing"
+
+	"github.com/libp2p/go-libp2p-peer"
+	"github.com/libp2p/go-libp2p-peer/test"
+)
+
+func TestPeerSerdePB(t *testing.T) {
+	id, err := testutil.RandPeerID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := id.Marshal()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var id2 peer.ID
+	if err = id2.Unmarshal(b); err != nil {
+		t.Fatal(err)
+	}
+	if id != id2 {
+		t.Error("expected equal ids in circular serde test")
+	}
+}
+
+func TestPeerSerdeJSON(t *testing.T) {
+	id, err := testutil.RandPeerID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := id.MarshalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var id2 peer.ID
+	if err = id2.UnmarshalJSON(b); err != nil {
+		t.Fatal(err)
+	}
+	if id != id2 {
+		t.Error("expected equal ids in circular serde test")
+	}
+}


### PR DESCRIPTION
Context: https://github.com/libp2p/go-libp2p-peerstore/pull/47/#discussion_r240467062