### PR TITLE
fix: re-enable peer ID inlining but make it configurable

### DIFF
--- a/peer.go
+++ b/peer.go
@@ -14,9 +14,24 @@ import (
 var (
 	// ErrEmptyPeerID is an error for empty peer ID.
 	ErrEmptyPeerID = errors.New("empty peer ID")
-	// ErrNoPublickKey is an error for peer IDs that don't embed public keys
+	// ErrNoPublicKey is an error for peer IDs that don't embed public keys
 	ErrNoPublicKey = errors.New("public key is not embedded in peer ID")
 )
+
+// AdvancedEnableInlining enables automatically inlining keys shorter than
+// 42 bytes into the peer ID (using the "identity" multihash function).
+//
+// WARNING: This flag will likely be set to false in the future and eventually
+// be removed in favor of using a hash function specified by the key itself.
+// See: https://github.com/libp2p/specs/issues/138
+//
+// DO NOT change this flag unless you know what you're doing.
+//
+// This currently defaults to true for backwards compatibility but will likely
+// be set to false by default when an upgrade path is determined.
+var AdvancedEnableInlining = true
+
+const maxInlineKeyLength = 42
 
 // ID is a libp2p peer identity.
 type ID string
@@ -141,7 +156,11 @@ func IDFromPublicKey(pk ic.PubKey) (ID, error) {
 	if err != nil {
 		return "", err
 	}
-	hash, _ := mh.Sum(b, mh.SHA2_256, -1)
+	var alg uint64 = mh.SHA2_256
+	if AdvancedEnableInlining && len(b) <= maxInlineKeyLength {
+		alg = mh.ID
+	}
+	hash, _ := mh.Sum(b, alg, -1)
 	return ID(hash), nil
 }
 


### PR DESCRIPTION
This should:

1. Unblock OpenBazaar. They were relying on the non-inlining behavior but run a forked network so they can set `EnableDeprecatedKeyInlining` to `false`.
2. Unblock Textile. They rely on this feature being *enabled*. Re-enabling it by default will give us some time to transition away from it.