### PR TITLE
Let ID implement encoding.Binary[Un]Marshaler and encoding.Text[Un]Marshaler

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-3.1.1: QmTu65MVbemtUxJEWgsTtzv9Zv9P8rvmqNA4eG9TrTRGYc
+3.1.2: QmYVXrKrKHDC9FobgmcmshCDyWwdrfwfanNQN4oxJ9Fk3h

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
   "license": "MIT",
   "name": "go-libp2p-peer",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "3.1.1"
+  "version": "3.1.2"
 }
 

--- a/peer_serde.go
+++ b/peer_serde.go
@@ -2,6 +2,7 @@
 package peer
 
 import (
+	"encoding"
 	"encoding/json"
 )
 
@@ -11,8 +12,18 @@ import (
 var _ json.Marshaler = (*ID)(nil)
 var _ json.Unmarshaler = (*ID)(nil)
 
+var _ encoding.BinaryMarshaler = (*ID)(nil)
+var _ encoding.BinaryUnmarshaler = (*ID)(nil)
+var _ encoding.TextMarshaler = (*ID)(nil)
+var _ encoding.TextUnmarshaler = (*ID)(nil)
+
 func (id ID) Marshal() ([]byte, error) {
 	return []byte(id), nil
+}
+
+// BinaryMarshal returns the byte representation of the peer ID.
+func (id ID) MarshalBinary() ([]byte, error) {
+	return id.Marshal()
 }
 
 func (id ID) MarshalTo(data []byte) (n int, err error) {
@@ -22,6 +33,11 @@ func (id ID) MarshalTo(data []byte) (n int, err error) {
 func (id *ID) Unmarshal(data []byte) (err error) {
 	*id, err = IDFromBytes(data)
 	return err
+}
+
+// BinaryUnmarshal sets the ID from its binary representation.
+func (id *ID) UnmarshalBinary(data []byte) error {
+	return id.Unmarshal(data)
 }
 
 // Implements Gogo's proto.Sizer, but we omit the compile-time assertion to avoid introducing a hard
@@ -41,4 +57,19 @@ func (id *ID) UnmarshalJSON(data []byte) (err error) {
 	}
 	*id, err = IDB58Decode(v)
 	return err
+}
+
+// TextMarshal returns the text encoding of the ID.
+func (id ID) MarshalText() ([]byte, error) {
+	return []byte(IDB58Encode(id)), nil
+}
+
+// TextUnmarshal restores the ID from its text encoding.
+func (id *ID) UnmarshalText(data []byte) error {
+	pid, err := IDB58Decode(string(data))
+	if err != nil {
+		return err
+	}
+	*id = pid
+	return nil
 }

--- a/peer_serde_test.go
+++ b/peer_serde_test.go
@@ -43,3 +43,41 @@ func TestPeerSerdeJSON(t *testing.T) {
 		t.Error("expected equal ids in circular serde test")
 	}
 }
+
+func TestBinaryMarshaler(t *testing.T) {
+	id, err := testutil.RandPeerID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := id.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var id2 peer.ID
+	if err = id2.UnmarshalBinary(b); err != nil {
+		t.Fatal(err)
+	}
+	if id != id2 {
+		t.Error("expected equal ids in circular serde test")
+	}
+}
+
+func TestTextMarshaler(t *testing.T) {
+	id, err := testutil.RandPeerID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := id.MarshalText()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var id2 peer.ID
+	if err = id2.UnmarshalText(b); err != nil {
+		t.Fatal(err)
+	}
+	if id != id2 {
+		t.Error("expected equal ids in circular serde test")
+	}
+}


### PR DESCRIPTION
When encoding a `map[peer.ID]something` to JSON it cannot be parsed back because `ID` doesn't implement `TextMarshaler`.

While the `BinaryMarshaler` is not strictly necessary, it is a safeguard in case at some point an ID is no longer an alias for a string.