### PR TITLE
Change ID.String to return the full "pretty" representation

### DIFF
--- a/peer.go
+++ b/peer.go
@@ -48,13 +48,17 @@ func (id ID) Loggable() map[string]interface{} {
 	}
 }
 
+func (id ID) String() string {
+	return id.Pretty()
+}
+
 // String prints out the peer.
 //
 // TODO(brian): ensure correctness at ID generation and
 // enforce this by only exposing functions that generate
 // IDs safely. Then any peer.ID type found in the
 // codebase is known to be correct.
-func (id ID) String() string {
+func (id ID) ShortString() string {
 	pid := id.Pretty()
 	if len(pid) <= 10 {
 		return fmt.Sprintf("<peer.ID %s>", pid)


### PR DESCRIPTION
The short form of the peer ID is okay for debugging and unit tests, but for real-world use, only the long-form of the "pretty" ID string is actually useful. It's also harder to visually scan for the short form in a long list as it favours the last bytes rather than the first ones. This change always prints the long "pretty" form. In particular, as a lot of downstream logging and printing rely on the default "%v", "%q" and "%s" handlers, we can't assume they're okay with the short-form (and they're not, I'm trying to debug live applications, and this is a nuisance).